### PR TITLE
LMMS .svg image

### DIFF
--- a/Surfn/scalable/apps/scalable/lmms.svg
+++ b/Surfn/scalable/apps/scalable/lmms.svg
@@ -1,1 +1,82 @@
-ardour.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="512"
+   height="513"
+   sodipodi:docname="lmms-solid.svg">
+  <metadata
+     id="metadata8">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs6" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1023"
+     id="namedview4"
+     showgrid="false"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="-149.50144"
+     inkscape:cy="138.0451"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:object-paths="true"
+     inkscape:snap-nodes="true"
+     inkscape:object-nodes="true" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Solid"
+     style="display:inline">
+    <g
+       id="g4181"
+       transform="matrix(1.0115852,0,0,1.0115852,-2.3720979,-2.9716053)">
+      <path
+         id="path4137"
+         d="M 255.41406,19.095703 8.6953125,161.53906 l 0,189.92188 82.2382815,47.48242 0.01758,94.95117 82.240236,-47.48047 -0.0176,-94.95312 -82.240234,-47.48047 0,-94.96094 164.480464,-94.96289 0,-94.960937 z m 246.7168,332.365237 -82.23828,47.48242 0,94.96094 82.23828,-47.48047 0,-94.96289 z"
+         style="opacity:1;fill:#6fff9f;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path4150"
+         d="m 255.41406,19.095703 0,94.960937 164.47852,94.96289 0,94.96094 -82.24024,47.48047 -0.0176,94.95312 82.24023,47.48047 0.0176,-94.95117 82.23828,-47.48242 0,-189.92188 L 255.41406,19.095703 Z M 8.6953125,351.46094 l 0,94.96289 82.2382815,47.48047 0,-94.96094 -82.2382815,-47.48242 z"
+         style="opacity:1;fill:#1fbc4b;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Previously, you didn't see the problem in Mint. I show the problem in these pictures clearly. THIS SHOULD FIX IT.

In these images, it is clear that your lmms.svg file is a symlink pointing to ardour.svg. This pull request replaces that symlink with an actual file, which I created myself, from https://github.com/inkVerb/icons/blob/master/lmms-solid.svg.

Please, pretty please, with sugar, accept my pull request or make the change yourself. The location is in ~/Surfn/Surfn/scalable/apps/scalable/

Thank you so much, Erik! I really love using your icons on my stuff.

![lmms1](https://user-images.githubusercontent.com/9209377/35793483-cb7234bc-0a8c-11e8-8163-af9a6e6fb486.png)
![lmms2](https://user-images.githubusercontent.com/9209377/35793491-d2ae19c6-0a8c-11e8-92e5-9e89e7c55b70.png)
